### PR TITLE
DOC: Rpy2 does not work with threadpools. Use processpool

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -185,15 +185,19 @@ they take time. This frees up Gramex to handle other requests.
 To do this, you must:
 
 - Decorate your FunctionHandler with `@tornado.gen.coroutine`
-- Call `yield gramex.service.threadpool.submit(gramex.ml.r, **kwargs)` instead
+- Create a `pool = concurrent.futures.ProcessPoolExecutor()`
+- Call `yield pool.submit(gramex.ml.r, **kwargs)` instead
   of `gramex.ml.r(**kwargs)`
 
 For example, here the asynchronous version of the plotting code above:
 
 ```python
+import concurrent.futures
+pool = concurrent.futures.ProcessPoolExecutor()
+
 @tornado.gen.coroutine
 def plot_async(handler):
-    path = yield gramex.service.threadpool(gramex.ml.r, path='path/to/plot.R')
+    path = yield pool.submit(gramex.ml.r, path='path/to/plot.R')
     raise tornado.gen.Return(gramex.cache.open(path[0], 'bin'))
 ```
 

--- a/r/rcalc.py
+++ b/r/rcalc.py
@@ -1,10 +1,12 @@
 import os
 import json
 import tornado.gen
+import concurrent.futures
 import gramex
 import gramex.ml
 
 folder = os.path.dirname(os.path.abspath(__file__))
+pool = concurrent.futures.ProcessPoolExecutor()
 
 
 def prime(handler):
@@ -21,8 +23,5 @@ def plot(handler):
 
 @tornado.gen.coroutine
 def plot_async(handler):
-    path = yield gramex.service.threadpool.submit(
-        gramex.ml.r,
-        path=os.path.join(folder, 'plot.R'),
-    )
+    path = yield pool.submit(gramex.ml.r, path=os.path.join(folder, 'plot.R'))
     raise tornado.gen.Return(gramex.cache.open(path[0], 'bin'))


### PR DESCRIPTION
[Rpy2 blocks threads](https://bitbucket.org/rpy2/rpy2/issues/449/rpy2-blocks-other-python-threads).

We showed an example of using ThreadPoolExecutor. This is NOT the right way to run R code in parallel (or even async).

This PR fixes it by replacing the code with ProcessPoolExecutor.

Thanks @bkamapantula